### PR TITLE
Market History fix and Market Price implementation

### DIFF
--- a/api/src/main/java/org/devfleet/crest/CrestService.java
+++ b/api/src/main/java/org/devfleet/crest/CrestService.java
@@ -2,18 +2,7 @@ package org.devfleet.crest;
 
 import java.util.List;
 
-import org.devfleet.crest.model.CrestCharacter;
-import org.devfleet.crest.model.CrestContact;
-import org.devfleet.crest.model.CrestFitting;
-import org.devfleet.crest.model.CrestLocation;
-import org.devfleet.crest.model.CrestMarketBulkOrder;
-import org.devfleet.crest.model.CrestMarketHistory;
-import org.devfleet.crest.model.CrestMarketOrder;
-import org.devfleet.crest.model.CrestMarketPrice;
-import org.devfleet.crest.model.CrestServerStatus;
-import org.devfleet.crest.model.CrestSolarSystem;
-import org.devfleet.crest.model.CrestType;
-import org.devfleet.crest.model.CrestWaypoint;
+import org.devfleet.crest.model.*;
 
 public interface CrestService {
 
@@ -28,6 +17,8 @@ public interface CrestService {
     CrestType getInventoryType (int typeId);
 
     List<CrestSolarSystem> getLocations();
+
+    List<CrestItem> getRegions();
 
     List<CrestContact> getContacts();
 

--- a/api/src/main/java/org/devfleet/crest/CrestService.java
+++ b/api/src/main/java/org/devfleet/crest/CrestService.java
@@ -9,6 +9,7 @@ import org.devfleet.crest.model.CrestLocation;
 import org.devfleet.crest.model.CrestMarketBulkOrder;
 import org.devfleet.crest.model.CrestMarketHistory;
 import org.devfleet.crest.model.CrestMarketOrder;
+import org.devfleet.crest.model.CrestMarketPrice;
 import org.devfleet.crest.model.CrestServerStatus;
 import org.devfleet.crest.model.CrestSolarSystem;
 import org.devfleet.crest.model.CrestWaypoint;
@@ -48,4 +49,6 @@ public interface CrestService {
     List<CrestMarketOrder> getMarketOrders(final long regionId, final String orderType, final long itemId);
 
     List<CrestMarketBulkOrder> getAllMarketOrders(final long regionId );
+    
+    List<CrestMarketPrice> getAllMarketPrices();
 }

--- a/api/src/main/java/org/devfleet/crest/CrestService.java
+++ b/api/src/main/java/org/devfleet/crest/CrestService.java
@@ -12,6 +12,7 @@ import org.devfleet.crest.model.CrestMarketOrder;
 import org.devfleet.crest.model.CrestMarketPrice;
 import org.devfleet.crest.model.CrestServerStatus;
 import org.devfleet.crest.model.CrestSolarSystem;
+import org.devfleet.crest.model.CrestType;
 import org.devfleet.crest.model.CrestWaypoint;
 
 public interface CrestService {
@@ -23,6 +24,8 @@ public interface CrestService {
     CrestLocation getLocation();
 
     CrestSolarSystem getSolarSystem(long solarSystemId);
+
+    CrestType getInventoryType (int typeId);
 
     List<CrestSolarSystem> getLocations();
 

--- a/retrofit/src/main/java/org/devfleet/crest/retrofit/CrestServiceImpl.java
+++ b/retrofit/src/main/java/org/devfleet/crest/retrofit/CrestServiceImpl.java
@@ -19,6 +19,7 @@ import org.devfleet.crest.model.CrestMarketOrder;
 import org.devfleet.crest.model.CrestMarketPrice;
 import org.devfleet.crest.model.CrestServerStatus;
 import org.devfleet.crest.model.CrestSolarSystem;
+import org.devfleet.crest.model.CrestType;
 import org.devfleet.crest.model.CrestWaypoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +53,17 @@ final class CrestServiceImpl extends AbstractCrestService {
     public CrestSolarSystem getSolarSystem(long solarSystemId) {
         try {
             return this.publicCrest().getSolarSystem(solarSystemId).execute().body();
+        }
+        catch (IOException e) {
+            LOG.error(e.getLocalizedMessage(), e);
+            throw new IllegalStateException(e.getLocalizedMessage(), e);
+        }
+    }
+
+    @Override
+    public CrestType getInventoryType (int typeId) {
+        try {
+            return this.publicCrest().getInventoryType(typeId).execute().body();
         }
         catch (IOException e) {
             LOG.error(e.getLocalizedMessage(), e);

--- a/retrofit/src/main/java/org/devfleet/crest/retrofit/CrestServiceImpl.java
+++ b/retrofit/src/main/java/org/devfleet/crest/retrofit/CrestServiceImpl.java
@@ -254,17 +254,13 @@ final class CrestServiceImpl extends AbstractCrestService {
         try {
             final List<CrestMarketHistory> returned = new ArrayList<>();
             CrestDictionary<CrestMarketHistory> dictionary;
-            int page = 0;
-            do {
-                page = page + 1;
-                dictionary = this.publicCrest().getMarketHistory(regionId, itemId, page).execute().body();
-                if (null == dictionary) {
-                    LOG.error("getMarketHistory: null dictionary {}, {}", regionId, itemId);
-                    break;
-                }
-                returned.addAll(dictionary.getItems());
+            
+            final String typePath = href("inventory/types") + itemId + "/";
+            dictionary = this.publicCrest().getMarketHistory(regionId, typePath).execute().body();
+            if (null == dictionary) {
+                LOG.error("getMarketHistory: null dictionary {}, {}", regionId, itemId);
             }
-            while (dictionary.getPageCount() > page);
+            returned.addAll(dictionary.getItems());
             return returned;
         }
         catch (IOException e) {

--- a/retrofit/src/main/java/org/devfleet/crest/retrofit/CrestServiceImpl.java
+++ b/retrofit/src/main/java/org/devfleet/crest/retrofit/CrestServiceImpl.java
@@ -83,6 +83,28 @@ final class CrestServiceImpl extends AbstractCrestService {
     }
 
     @Override
+    public List<CrestItem> getRegions ( ) {
+        try {
+            final List<CrestItem> returned = new ArrayList<>();
+            CrestDictionary<CrestItem> dictionary;
+            int page = 0;
+            do {
+                page = page + 1;
+                dictionary = this.publicCrest().getRegions().execute().body();
+                if (null == dictionary) {
+                    LOG.error("getRegions: null dictionary");
+                    break;
+                }
+                returned.addAll(dictionary.getItems());
+            } while (dictionary.getPageCount() > page);
+            return returned;
+        } catch (IOException e) {
+            LOG.error(e.getLocalizedMessage(), e);
+            throw new IllegalStateException(e.getLocalizedMessage(), e);
+        }
+    }
+
+    @Override
     public CrestCharacter getCharacter() {
         final CrestCharacterStatus status = getCharacterStatus();
         try {

--- a/retrofit/src/main/java/org/devfleet/crest/retrofit/CrestServiceImpl.java
+++ b/retrofit/src/main/java/org/devfleet/crest/retrofit/CrestServiceImpl.java
@@ -16,6 +16,7 @@ import org.devfleet.crest.model.CrestLocation;
 import org.devfleet.crest.model.CrestMarketBulkOrder;
 import org.devfleet.crest.model.CrestMarketHistory;
 import org.devfleet.crest.model.CrestMarketOrder;
+import org.devfleet.crest.model.CrestMarketPrice;
 import org.devfleet.crest.model.CrestServerStatus;
 import org.devfleet.crest.model.CrestSolarSystem;
 import org.devfleet.crest.model.CrestWaypoint;
@@ -258,7 +259,7 @@ final class CrestServiceImpl extends AbstractCrestService {
                 page = page + 1;
                 dictionary = this.publicCrest().getMarketHistory(regionId, itemId, page).execute().body();
                 if (null == dictionary) {
-                    LOG.error("getMarketHistory: null dictionnary {}, {}", regionId, itemId);
+                    LOG.error("getMarketHistory: null dictionary {}, {}", regionId, itemId);
                     break;
                 }
                 returned.addAll(dictionary.getItems());
@@ -300,7 +301,7 @@ final class CrestServiceImpl extends AbstractCrestService {
                 page = page + 1;
                 dictionary = this.publicCrest().getAllMarketOrders(regionId, page).execute().body();
                 if (null == dictionary) {
-                    LOG.error("getAllOrders: null dictionnary {}, {}", regionId);
+                    LOG.error("getAllMarketOrders: null dictionary {}", regionId);
                     break;
                 }
                 returned.addAll(dictionary.getItems());
@@ -310,6 +311,29 @@ final class CrestServiceImpl extends AbstractCrestService {
             LOG.error(e.getLocalizedMessage(), e);
             throw new IllegalStateException(e.getLocalizedMessage(), e);
         }
+    }
+    
+    @Override
+    public List<CrestMarketPrice> getAllMarketPrices() {
+    	try {
+    		final List<CrestMarketPrice> returned = new ArrayList<>();
+    		
+    		CrestDictionary<CrestMarketPrice> dictionary;
+    		int page = 0;
+    		do {
+    			page = page + 1;
+    			dictionary = this.publicCrest().getAllMarketPrices(page).execute().body();
+    			if (null == dictionary) {
+    				LOG.error("getAllMarketPrices: null dictionary {}", page);
+    			}
+    			returned.addAll(dictionary.getItems());
+    		} while (dictionary.getPageCount() > page);
+    		return returned;
+    	}
+    	catch (IOException e) {
+    		LOG.error(e.getLocalizedMessage());
+    		throw new IllegalStateException(e.getLocalizedMessage(), e);
+    	}
     }
 
     private String href(String path) {

--- a/retrofit/src/main/java/org/devfleet/crest/retrofit/CrestServiceImpl.java
+++ b/retrofit/src/main/java/org/devfleet/crest/retrofit/CrestServiceImpl.java
@@ -311,24 +311,24 @@ final class CrestServiceImpl extends AbstractCrestService {
     
     @Override
     public List<CrestMarketPrice> getAllMarketPrices() {
-    	try {
-    		final List<CrestMarketPrice> returned = new ArrayList<>();
-    		
-    		CrestDictionary<CrestMarketPrice> dictionary;
-    		int page = 0;
-    		do {
-    			page = page + 1;
-    			dictionary = this.publicCrest().getAllMarketPrices(page).execute().body();
-    			if (null == dictionary) {
-    				LOG.error("getAllMarketPrices: null dictionary {}", page);
-    			}
-    			returned.addAll(dictionary.getItems());
-    		} while (dictionary.getPageCount() > page);
-    		return returned;
-    	}
-    	catch (IOException e) {
-    		LOG.error(e.getLocalizedMessage());
-    		throw new IllegalStateException(e.getLocalizedMessage(), e);
+         try {
+            final List<CrestMarketPrice> returned = new ArrayList<>();
+
+            CrestDictionary<CrestMarketPrice> dictionary;
+            int page = 0;
+            do {
+                page = page + 1;
+                dictionary = this.publicCrest().getAllMarketPrices(page).execute().body();
+                if (null == dictionary) {
+                    LOG.error("getAllMarketPrices: null dictionary {}", page);
+                }
+                returned.addAll(dictionary.getItems());
+            } while (dictionary.getPageCount() > page);
+            return returned;
+        }
+        catch (IOException e) {
+            LOG.error(e.getLocalizedMessage());
+            throw new IllegalStateException(e.getLocalizedMessage(), e);
     	}
     }
 

--- a/retrofit/src/main/java/org/devfleet/crest/retrofit/PublicService.java
+++ b/retrofit/src/main/java/org/devfleet/crest/retrofit/PublicService.java
@@ -1,13 +1,6 @@
 package org.devfleet.crest.retrofit;
 
-import org.devfleet.crest.model.CrestDictionary;
-import org.devfleet.crest.model.CrestMarketBulkOrder;
-import org.devfleet.crest.model.CrestMarketHistory;
-import org.devfleet.crest.model.CrestMarketOrder;
-import org.devfleet.crest.model.CrestMarketPrice;
-import org.devfleet.crest.model.CrestServerStatus;
-import org.devfleet.crest.model.CrestSolarSystem;
-import org.devfleet.crest.model.CrestType;
+import org.devfleet.crest.model.*;
 
 import retrofit2.Call;
 import retrofit2.http.GET;
@@ -21,6 +14,9 @@ interface PublicService {
 
     @GET("/solarsystems/")
     Call<CrestDictionary<CrestSolarSystem>> getSolarSystems();
+
+    @GET("/regions/")
+    Call<CrestDictionary<CrestItem>> getRegions();
 
     @GET("/")
     Call<CrestServerStatus> getServerStatus();

--- a/retrofit/src/main/java/org/devfleet/crest/retrofit/PublicService.java
+++ b/retrofit/src/main/java/org/devfleet/crest/retrofit/PublicService.java
@@ -24,11 +24,10 @@ interface PublicService {
     @GET("/")
     Call<CrestServerStatus> getServerStatus();
 
-    @GET("/market/{regionId}/types/{itemId}/history/")
+    @GET("/market/{regionId}/history/")
     Call<CrestDictionary<CrestMarketHistory>> getMarketHistory(
             @Path("regionId") final long regionId,
-            @Path("itemId") final long itemId,
-            @Query("page") final int page);
+            @Query("type") final String typePath);
 
     //https://public-crest.eveonline.com/market/10000002/orders/buy/?type=http://public-crest.eveonline.com/types/32772/
     @GET("/market/{regionId}/orders/{orderType}/")

--- a/retrofit/src/main/java/org/devfleet/crest/retrofit/PublicService.java
+++ b/retrofit/src/main/java/org/devfleet/crest/retrofit/PublicService.java
@@ -7,6 +7,7 @@ import org.devfleet.crest.model.CrestMarketOrder;
 import org.devfleet.crest.model.CrestMarketPrice;
 import org.devfleet.crest.model.CrestServerStatus;
 import org.devfleet.crest.model.CrestSolarSystem;
+import org.devfleet.crest.model.CrestType;
 
 import retrofit2.Call;
 import retrofit2.http.GET;
@@ -23,6 +24,9 @@ interface PublicService {
 
     @GET("/")
     Call<CrestServerStatus> getServerStatus();
+
+    @GET("/inventory/types/{typeId}/")
+    Call<CrestType> getInventoryType (@Path("typeId") final int typeId);
 
     @GET("/market/{regionId}/history/")
     Call<CrestDictionary<CrestMarketHistory>> getMarketHistory(

--- a/retrofit/src/main/java/org/devfleet/crest/retrofit/PublicService.java
+++ b/retrofit/src/main/java/org/devfleet/crest/retrofit/PublicService.java
@@ -4,6 +4,7 @@ import org.devfleet.crest.model.CrestDictionary;
 import org.devfleet.crest.model.CrestMarketBulkOrder;
 import org.devfleet.crest.model.CrestMarketHistory;
 import org.devfleet.crest.model.CrestMarketOrder;
+import org.devfleet.crest.model.CrestMarketPrice;
 import org.devfleet.crest.model.CrestServerStatus;
 import org.devfleet.crest.model.CrestSolarSystem;
 
@@ -40,4 +41,7 @@ interface PublicService {
     Call<CrestDictionary<CrestMarketBulkOrder>> getAllMarketOrders (
             @Path("regionId") final long regionId,
             @Query("page") final int page);
+    
+    @GET("/market/prices/")
+    Call<CrestDictionary<CrestMarketPrice>> getAllMarketPrices (@Query("page") final int page);
 }

--- a/retrofit/src/test/java/org/devfleet/crest/retrofit/PublicCRESTTest.java
+++ b/retrofit/src/test/java/org/devfleet/crest/retrofit/PublicCRESTTest.java
@@ -43,11 +43,11 @@ public final class PublicCRESTTest {
     }
     
     @Test
-  @Ignore
-  public void testGetJita150mmRailIIMarketHistory() {
-      final List<CrestMarketHistory> h = service.getMarketHistory(10000002, 23713);
-      Assert.assertFalse(h.isEmpty());
-  }
+    @Ignore
+    public void testGetJita150mmRailIIMarketHistory() {
+        final List<CrestMarketHistory> h = service.getMarketHistory(10000002, 23713);
+        Assert.assertFalse(h.isEmpty());
+    }
 
     @Test
     @Ignore
@@ -63,11 +63,11 @@ public final class PublicCRESTTest {
         final List<CrestMarketBulkOrder> bo = service.getAllMarketOrders(10000002);
         Assert.assertFalse(bo.isEmpty());
     }
-    
+
     @Test
-//    @Ignore
+    @Ignore
     public void testGetAllMarketPrices ( ) {
-    	final List<CrestMarketPrice> prices = service.getAllMarketPrices();
-    	Assert.assertFalse(prices.isEmpty());
+        final List<CrestMarketPrice> prices = service.getAllMarketPrices();
+        Assert.assertFalse(prices.isEmpty());
     }
 }

--- a/retrofit/src/test/java/org/devfleet/crest/retrofit/PublicCRESTTest.java
+++ b/retrofit/src/test/java/org/devfleet/crest/retrofit/PublicCRESTTest.java
@@ -1,14 +1,12 @@
 package org.devfleet.crest.retrofit;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.devfleet.crest.CrestService;
-import org.devfleet.crest.model.CrestDictionary;
 import org.devfleet.crest.model.CrestMarketBulkOrder;
 import org.devfleet.crest.model.CrestMarketHistory;
 import org.devfleet.crest.model.CrestMarketOrder;
+import org.devfleet.crest.model.CrestMarketPrice;
 import org.devfleet.crest.model.CrestSolarSystem;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -16,10 +14,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
 
 public final class PublicCRESTTest {
 
@@ -61,5 +55,12 @@ public final class PublicCRESTTest {
     public void testGetAllMarketOrders ( ) {
         final List<CrestMarketBulkOrder> bo = service.getAllMarketOrders(10000002);
         Assert.assertFalse(bo.isEmpty());
+    }
+    
+    @Test
+    @Ignore
+    public void testGetAllMarketPrices ( ) {
+    	final List<CrestMarketPrice> prices = service.getAllMarketPrices();
+    	Assert.assertFalse(prices.isEmpty());
     }
 }

--- a/retrofit/src/test/java/org/devfleet/crest/retrofit/PublicCRESTTest.java
+++ b/retrofit/src/test/java/org/devfleet/crest/retrofit/PublicCRESTTest.java
@@ -8,6 +8,7 @@ import org.devfleet.crest.model.CrestMarketHistory;
 import org.devfleet.crest.model.CrestMarketOrder;
 import org.devfleet.crest.model.CrestMarketPrice;
 import org.devfleet.crest.model.CrestSolarSystem;
+import org.devfleet.crest.model.CrestType;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -69,5 +70,13 @@ public final class PublicCRESTTest {
     public void testGetAllMarketPrices ( ) {
         final List<CrestMarketPrice> prices = service.getAllMarketPrices();
         Assert.assertFalse(prices.isEmpty());
+    }
+
+    @Test
+    @Ignore
+    public void testGet150mmLightAutoCannonInventoryType ( ) {
+        final CrestType type = service.getInventoryType(485);
+        Assert.assertNotNull(type);
+        Assert.assertEquals(type.getName(), "150mm Light AutoCannon I");
     }
 }

--- a/retrofit/src/test/java/org/devfleet/crest/retrofit/PublicCRESTTest.java
+++ b/retrofit/src/test/java/org/devfleet/crest/retrofit/PublicCRESTTest.java
@@ -3,12 +3,7 @@ package org.devfleet.crest.retrofit;
 import java.util.List;
 
 import org.devfleet.crest.CrestService;
-import org.devfleet.crest.model.CrestMarketBulkOrder;
-import org.devfleet.crest.model.CrestMarketHistory;
-import org.devfleet.crest.model.CrestMarketOrder;
-import org.devfleet.crest.model.CrestMarketPrice;
-import org.devfleet.crest.model.CrestSolarSystem;
-import org.devfleet.crest.model.CrestType;
+import org.devfleet.crest.model.*;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -78,5 +73,13 @@ public final class PublicCRESTTest {
         final CrestType type = service.getInventoryType(485);
         Assert.assertNotNull(type);
         Assert.assertEquals(type.getName(), "150mm Light AutoCannon I");
+    }
+
+    @Test
+    @Ignore
+    public void testGetRegions ( ) {
+        final List<CrestItem> regions = service.getRegions();
+        Assert.assertNotNull(regions);
+        Assert.assertEquals(regions.size(), 100);
     }
 }

--- a/retrofit/src/test/java/org/devfleet/crest/retrofit/PublicCRESTTest.java
+++ b/retrofit/src/test/java/org/devfleet/crest/retrofit/PublicCRESTTest.java
@@ -41,6 +41,13 @@ public final class PublicCRESTTest {
         final List<CrestMarketHistory> h = service.getMarketHistory(10000033, 23713);
         Assert.assertFalse(h.isEmpty());
     }
+    
+    @Test
+  @Ignore
+  public void testGetJita150mmRailIIMarketHistory() {
+      final List<CrestMarketHistory> h = service.getMarketHistory(10000002, 23713);
+      Assert.assertFalse(h.isEmpty());
+  }
 
     @Test
     @Ignore
@@ -58,7 +65,7 @@ public final class PublicCRESTTest {
     }
     
     @Test
-    @Ignore
+//    @Ignore
     public void testGetAllMarketPrices ( ) {
     	final List<CrestMarketPrice> prices = service.getAllMarketPrices();
     	Assert.assertFalse(prices.isEmpty());


### PR DESCRIPTION
As the commits say, the Market History endpoint was changed completely to take a type query parameter and not have the type id embedded in the URL.

Market Price endpoint implementation to use the already defined CrestMarketPrice class.
