### PR TITLE
BulkOrder and DateTimeSerializer

### DIFF
--- a/api/src/main/java/org/devfleet/crest/model/CrestMarketBulkOrder.java
+++ b/api/src/main/java/org/devfleet/crest/model/CrestMarketBulkOrder.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class CrestMarketBulkOrder extends CrestMarketOrder {
     @JsonProperty
     private long type;
+    @JsonProperty("stationID")
+    private long stationId;
 
     public long getType() {
         return type;
@@ -12,5 +14,13 @@ public class CrestMarketBulkOrder extends CrestMarketOrder {
 
     public void setType(long type) {
         this.type = type;
+    }
+
+    public long getStationId ( ) {
+        return stationId;
+    }
+
+    public void setStationId ( long stationId ) {
+        this.stationId = stationId;
     }
 }

--- a/api/src/main/java/org/devfleet/crest/model/CrestMarketOrder.java
+++ b/api/src/main/java/org/devfleet/crest/model/CrestMarketOrder.java
@@ -2,6 +2,7 @@ package org.devfleet.crest.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public class CrestMarketOrder extends CrestItem {
 
@@ -10,6 +11,7 @@ public class CrestMarketOrder extends CrestItem {
 
     @JsonProperty
     @JsonDeserialize(using = DateTimeDeserializer.class)
+    @JsonSerialize(using = DateTimeSerializer.class)
     private long issued;
 
     @JsonProperty

--- a/api/src/main/java/org/devfleet/crest/model/DateTimeSerializer.java
+++ b/api/src/main/java/org/devfleet/crest/model/DateTimeSerializer.java
@@ -1,0 +1,27 @@
+package org.devfleet.crest.model;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Created by maurerit on 8/13/16.
+ */
+public class DateTimeSerializer extends StdSerializer<Long> {
+
+    public DateTimeSerializer() {
+        super(Long.class);
+    }
+
+    @Override
+    public void serialize ( Long value, JsonGenerator gen, SerializerProvider provider ) throws IOException {
+        final SimpleDateFormat f = new SimpleDateFormat( "yyyy-MM-dd'T'HH:mm:ss");
+        Date date = new Date(value);
+        String dateFormatted = f.format(date);
+        gen.writeString(dateFormatted);
+    }
+}


### PR DESCRIPTION
The use case in which I'm using this requires that the CrestMarketOrder object be serializable to be deserialized again by this library.  Without the serializer these objects fail to deserialize.

The CrestMarketBulkOrder class needs some rethinking.  While it shares some things with the CrestMarketOrder it doesn't make sense to extend it.  Rather, these two should fork from a shared base class.  I'll probably get to that later.  This pull request add's a property that isn't on the CrestMarketOrder but IS on the CrestMarketBulkOrder.
